### PR TITLE
fix: fail builds when there's an error

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -50,7 +50,7 @@ module.exports = function build(dsConfig) {
             if (messages.errors.length > 1) {
                 messages.errors.length = 1;
             }
-            return new Error(messages.errors.join("\n\n"));
+            throw new Error(messages.errors.join("\n\n"));
         }
 
         const resolveArgs = {


### PR DESCRIPTION
Summary:
When there's an error, we're logging and returning the error instead of throwing
it.  This results in a build success instead of a failure.  We should throw the error instead.

Test Plan:
Updated the code and tested with an error condition. 
The build now fails and halts `ant build-assets` in operations as expected.